### PR TITLE
Update Required Libraries in PlatformIO.ini

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -17,6 +17,5 @@ lib_deps =
   1089
   567
   64
-  1734
-  551
+  44
   https://github.com/jjssoftware/Cryptosuite


### PR DESCRIPTION
REMOVE old required EasyNTPClient and NTPClient libraries and ADD new required Time library.