### PR TITLE
Fix compile, miscellaneous cleanup

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -9,7 +9,7 @@
 ; http://docs.platformio.org/page/projectconf.html
 
 [env:esp12e]
-platform = https://github.com/platformio/platform-espressif8266.git#feature/2.4.0-rc2
+platform = espressif8266@~1.8.0
 board = nodemcuv2
 framework = arduino
 build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH

--- a/platformio.ini
+++ b/platformio.ini
@@ -14,8 +14,8 @@ board = nodemcuv2
 framework = arduino
 build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
 lib_deps =
-  1089
-  567
-  64
-  44
+  IRremoteESP8266@~2.6.0
+  WifiManager@~0.14
+  ArduinoJson@<6
+  Time@~1.5
   https://github.com/jjssoftware/Cryptosuite

--- a/src/IRController.ino
+++ b/src/IRController.ino
@@ -633,7 +633,7 @@ void setup() {
 
       String message = "Code sent";
 
-      for (int x = 0; x < root.size(); x++) {
+      for (size_t x = 0; x < root.size(); x++) {
         String type = root[x]["type"];
         String ip = root[x]["ip"];
         int rdelay = root[x]["rdelay"];

--- a/src/IRController.ino
+++ b/src/IRController.ino
@@ -37,7 +37,7 @@ const int pins4 = 13;                                         // Transmitting pr
 const int configpin = 10;                                     // Reset Pin
 
 // User settings are above here
-const int ledpin = BUILTIN_LED;                               // Built in LED defined for WEMOS people
+const int ledpin = LED_BUILTIN;                               // Built in LED defined for WEMOS people
 const char *wifi_config_name = "IR Controller Configuration";
 const char serverName[] = "checkip.dyndns.org";
 int port = 80;


### PR DESCRIPTION
The code was not compiling because it's incompatible with ArduinoJson v6, which was recently released.

### Summary of changes

* Rename `BUILTIN_LED` -> `LED_BUILTIN` (the former is deprecated)
* Use released version of PlatformIO espressif8266 platform (points at Arduino SDK v2.4)
* Use library names instead of IDs (easier to see what's going on)
* Fix library versions (important one here is `ArduinoJson@<6`)
* Fix a compiler warning

If you end up merging #253, you'd want to change the constraint for ArduinoJson to something like `ArduinoJson@~6.11.0`.