### PR TITLE
fix ArduinoJson version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,6 @@ build_flags = -D PIO_FRAMEWORK_ARDUINO_LWIP_HIGHER_BANDWIDTH
 lib_deps =
   1089
   567
-  64
+  64@5.13.4
   44
   https://github.com/jjssoftware/Cryptosuite


### PR DESCRIPTION
On a fresh install (cloning the repo and running with platformio), the build fails because version 6 of arduinoJson is incompatible with the code. Adding the version number in the config file fixes this.