### PR TITLE
Reverting to stable ArduinoJson version

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -19,3 +19,4 @@ lib_deps =
   64
   44
   https://github.com/jjssoftware/Cryptosuite
+  ArduinoJson@~5.13.4


### PR DESCRIPTION
 **_'DynamicJsonBuffer' does not name a type_**  error resolved

Reverting to stable ArduinoJson version